### PR TITLE
Simplified lisp-unit Interface

### DIFF
--- a/tests/asdf-test-operation.lisp
+++ b/tests/asdf-test-operation.lisp
@@ -27,4 +27,4 @@
 (in-package "LISP-EXECUTABLE.TESTS")
 
 (defmethod asdf:perform ((operation asdf:test-op) (component (eql (asdf:find-system "lisp-executable-tests"))))
-  (lisp-unit:run-all-tests "LISP-EXECUTABLE.TESTS"))
+  (lisp-unit:run-tests :all "LISP-EXECUTABLE.TESTS"))


### PR DESCRIPTION
The lisp-unit interface has been simplified. This pull will update the call to remove-all-tests to conform to the simplified interface.
