### PR TITLE
Clisp creation

### DIFF
--- a/src/creation-clisp.lisp
+++ b/src/creation-clisp.lisp
@@ -95,6 +95,7 @@ exit $?
 		  bin-output-file
 		  :quiet t
 		  :verbose nil
+		  :norc t
 		  :script nil
 		  :documentation nil
 		  :init-function function

--- a/src/creation-clisp.lisp
+++ b/src/creation-clisp.lisp
@@ -80,9 +80,8 @@
     (with-open-file (out output-file :direction :output)
       (format out "#!/bin/sh
 set -e
-~A -- $@
-exit $?
-" bin-output-file))
+exec \"`dirname \"$0\"`/~A\" -- \"$@\"
+" (make-pathname :defaults bin-output-file :directory nil)))
     (when (ext:run-program "/bin/chmod" :arguments (list "+x" (truename output-file)) :wait t)
       (error "Unable to execute chmod on shell script."))
     (dotimes (i 10)


### PR DESCRIPTION
Hi. I have some improvements for the executable creation in CLISP.
1. Disable loading the clisprc file. First this is probably what the programmer expects, and second it improves startup time immensely when you have quicklisp there. Also it silences a ton of startup warnings of method redefinitions, due to ASDF getting loaded twice.
2. The wrapper script is rewritten with some improvements.
   First, I make the script movable by not hardcoding the path. I compute the script location according to the program name in $0.
   Second, it is a small optimization to use exec so the /bin/sh process is replaced and does not stay in memory.
   Third, I fix argument passing by double-quoting special variable "$@" as POSIX shell requires it.
   I tested it in the dash shell (small POSIX compliant), zsh and of course bash
